### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     implementation "com.enonic.xp:admin-api:${xpVersion}"
     implementation "com.enonic.xp:portal-api:${xpVersion}"
 
-    include "com.fasterxml.jackson.jr:jackson-jr-objects:2.21.3"
+    include libs.jackson.jr.objects
     include "com.enonic.xp:lib-app:${xpVersion}"
     include "com.enonic.xp:lib-admin:${xpVersion}"
     include "com.enonic.xp:lib-auth:${xpVersion}"
@@ -52,15 +52,15 @@ dependencies {
     include "com.enonic.xp:lib-task:${xpVersion}"
     include "com.enonic.xp:lib-websocket:${xpVersion}"
     include "com.enonic.xp:lib-event:${xpVersion}"
-    include 'com.enonic.lib:lib-http-client:4.0.0-SNAPSHOT'
-    include "com.enonic.lib:lib-mustache:2.1.1"
-    include "com.enonic.lib:lib-static:3.0.0-SNAPSHOT"
-    include "com.enonic.lib:lib-router:4.0.0-SNAPSHOT"
+    include libs.lib.http.client
+    include libs.lib.mustache
+    include libs.lib.static
+    include libs.lib.router
 
     testImplementation( testFixtures( "com.enonic.xp:core-api" ) )
     testImplementation "com.enonic.xp:testing:${xpVersion}"
-    testImplementation(platform("org.junit:junit-bom:6.0.3"))
-    testImplementation(platform("org.mockito:mockito-bom:5.23.0"))
+    testImplementation(platform(libs.junit.bom))
+    testImplementation(platform(libs.mockito.bom))
     testImplementation 'org.junit.jupiter:junit-jupiter'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
     testImplementation 'org.mockito:mockito-junit-jupiter'

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,17 @@
+[versions]
+http-client = "4.0.0-SNAPSHOT"
+jackson-jr-objects = "2.21.3"
+junit-bom = "6.0.3"
+mockito-bom = "5.23.0"
+mustache = "2.1.1"
+router = "4.0.0-SNAPSHOT"
+static = "3.0.0-SNAPSHOT"
+
+[libraries]
+jackson-jr-objects = { module = "com.fasterxml.jackson.jr:jackson-jr-objects", version.ref = "jackson-jr-objects" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit-bom" }
+lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-client" }
+lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }
+lib-router = { module = "com.enonic.lib:lib-router", version.ref = "router" }
+lib-static = { module = "com.enonic.lib:lib-static", version.ref = "static" }
+mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito-bom" }


### PR DESCRIPTION
## Summary

Move inline dependency versions in `build.gradle` to a new `gradle/libs.versions.toml` catalog. Pin-for-pin migration — no version bumps.

### Conventions adopted

- Alphabetical sort in both `[versions]` and `[libraries]`.
- Short, lowercase, hyphen-separated version keys (`http-client`, `mustache`, `junit-bom`, …).
- Library keys mirror the artifact name: `lib-mustache`, `lib-static`, `lib-router`, `lib-http-client`; BOMs use the unprefixed name (`junit-bom`, `mockito-bom`).
- `xpVersion` is intentionally left in `gradle.properties`; the rest of the toolchain expects it there.
- The `xplibs.*` accessors are untouched — they come from the XP gradle plugin, not this project's own catalog.
- Versionless test deps (`org.junit.jupiter:junit-jupiter`, `org.junit.platform:junit-platform-launcher`, `org.mockito:mockito-junit-jupiter`) stay as raw strings since they pull their version from their BOMs.

### Catalog content

```toml
[versions]
http-client = "4.0.0-SNAPSHOT"
jackson-jr-objects = "2.21.3"
junit-bom = "6.0.3"
mockito-bom = "5.23.0"
mustache = "2.1.1"
router = "4.0.0-SNAPSHOT"
static = "3.0.0-SNAPSHOT"

[libraries]
jackson-jr-objects = { module = "com.fasterxml.jackson.jr:jackson-jr-objects", version.ref = "jackson-jr-objects" }
junit-bom = { module = "org.junit:junit-bom", version.ref = "junit-bom" }
lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-client" }
lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }
lib-router = { module = "com.enonic.lib:lib-router", version.ref = "router" }
lib-static = { module = "com.enonic.lib:lib-static", version.ref = "static" }
mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito-bom" }
```

## Verification

- `./gradlew dependencies --configuration runtimeClasspath` and `--configuration testRuntimeClasspath` are byte-identical before and after (only build-duration line differs).
- `./gradlew build --refresh-dependencies` is green: all tasks executed including `test`, `jacocoTestReport`, `lint`, and `vite`.

## Test plan

- [x] `./gradlew build --refresh-dependencies` is green locally
- [x] Pre/post diff of `runtimeClasspath` and `testRuntimeClasspath` is empty
- [ ] CI green on the PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)